### PR TITLE
Adding 'Catalog' support, finishing 'CollectionRepository', fleshing out 'Console' var storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Haystac
-Spatio-temporal Asset Catalog suite implemented in .NET
+
+- [Haystac](#haystac)
+    - [Overview](#overview)
+    - [Technologies](#technologies)
+- [Getting Started](#getting-started)
+
+## Overview
+
+`Haystac` is an ASP.NET Spatio-Temporal Asset Catalog ([STAC](https://github.com/radiantearth/stac-spec)) solution that offers both a web API and client CLI for interacting with your STAC entities.
+
+The goal of this project is offer an open-source, secured, and configurable STAC solution that is easily extendable to any consumer's use case.
+
+The project is heavily inspired by the [Clean Architecture](https://github.com/jasontaylordev/CleanArchitecture/tree/net7.0) project template developed by Jason Taylor et al.
+
+## Technologies
+* [ASP.NET Core 7](https://docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core)
+* [Entity Framework Core 7](https://docs.microsoft.com/en-us/ef/core/)
+* [Npgsql & NetTopologySuite](https://www.npgsql.org/efcore/mapping/nts.html?tabs=with-datasource)
+* [MediatR](https://github.com/jbogard/MediatR)
+* [FluentValidation](https://fluentvalidation.net/)
+
+# Getting Started
+
+TODO

--- a/src/Application/Collections/Commands/CreateCollectionCommandValidator.cs
+++ b/src/Application/Collections/Commands/CreateCollectionCommandValidator.cs
@@ -6,14 +6,24 @@ public class CreateCollectionCommandValidator : AbstractValidator<CreateCollecti
 {
     private readonly IApplicationDbContext _context;
 
+    private readonly ICollection<string> _allowedTypes 
+        = new HashSet<string> { "Collection", "Catalog" };
+
     public CreateCollectionCommandValidator(IApplicationDbContext context)
     {
         _context = context;
+
+        RuleFor(v => v.Dto.Type)
+            .NotEmpty().WithMessage("Must specify if this is a 'Collection' or 'Catalog'")
+            .MustAsync(BeAllowedType).WithMessage("The 'Type' field must be one of 'Collection' or 'Catalog'");
 
         RuleFor(v => v.Dto.Identifier)
             .NotEmpty().WithMessage("Collection identifier is required")
             .MustAsync(BeUniqueName).WithMessage("The specified Collection identifier already exists");
     }
+
+    public Task<bool> BeAllowedType(string type, CancellationToken cancellationToken)
+        =>  Task.FromResult(_allowedTypes.Contains(type));
 
     public async Task<bool> BeUniqueName(string name, CancellationToken cancellationToken)
         => await _context.Collections.AllAsync(c => c.Identifier != name, cancellationToken);

--- a/src/Application/Collections/Queries/GetAllCollectionsQuery.cs
+++ b/src/Application/Collections/Queries/GetAllCollectionsQuery.cs
@@ -1,9 +1,9 @@
 ﻿namespace Haystac.Application.Collections.Queries;
 
-public record GetAllCollectionsQuery : IRequest<List<Collection>> { }
+public record GetAllCollectionsQuery : IRequest<List<CollectionDto>> { }
 
 public class GetAllCollectionsQueryHandler 
-    : IRequestHandler<GetAllCollectionsQuery, List<Collection>> 
+    : IRequestHandler<GetAllCollectionsQuery, List<CollectionDto>> 
 {
     private readonly IApplicationDbContext _context;
 
@@ -12,8 +12,8 @@ public class GetAllCollectionsQueryHandler
         _context = context;
     }
 
-    public async Task<List<Collection>> Handle(GetAllCollectionsQuery request, CancellationToken cancellationToken)
+    public async Task<List<CollectionDto>> Handle(GetAllCollectionsQuery request, CancellationToken cancellationToken)
         => await _context.Collections
-                         .Include(c => c.Items)
+                         .Select(c => c.ToDto())
                          .ToListAsync(cancellationToken);
 }

--- a/src/Application/Common/Models/CollectionDto.cs
+++ b/src/Application/Common/Models/CollectionDto.cs
@@ -5,7 +5,7 @@ namespace Haystac.Application.Common.Models;
 public class CollectionDto
 {
     [JsonPropertyName("type")]
-    public string Type { get; } = "Collection";
+    public string Type { get; set; } = string.Empty;
 
     [JsonPropertyName("stac_version")]
     public string StacVersion { get; set; } = string.Empty;
@@ -58,6 +58,7 @@ public static class CollectionDtoExtensions
     {
         return new CollectionDto
         {
+            Type = collection.Type,
             StacVersion = collection.StacVersion,
             Extensions = collection.Extensions,
             Identifier = collection.Identifier,
@@ -77,6 +78,7 @@ public static class CollectionDtoExtensions
     {
         return new Collection
         {
+            Type = dto.Type,
             StacVersion = dto.StacVersion,
             Extensions = dto.Extensions,
             Identifier = dto.Identifier,

--- a/src/Console/Application/Collections/CollectionDeleteCommand.cs
+++ b/src/Console/Application/Collections/CollectionDeleteCommand.cs
@@ -1,0 +1,32 @@
+﻿namespace Haystac.Console.Application.Collections;
+
+public class CollectionDeleteCommand : AsyncCommand<CollectionDeleteCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<CollectionId>")]
+        [Description("Name of the Collection to remove the item from")]
+        public string CollectionId { get; set; } = string.Empty;
+    }
+
+    private readonly ICollectionRepository _collections;
+
+    public CollectionDeleteCommand(ICollectionRepository collections)
+    {
+        _collections = collections;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        Helper.WriteDivider($"Deleting Collection");
+
+        Helper.Write("Attempting to delete the following:");
+        Helper.Write($"Collection: [yellow]{settings.CollectionId.EscapeMarkup()}[/]");
+
+        await _collections.DeleteCollectionAsync(settings.CollectionId);
+
+        Helper.Write($"\t .. Done!");
+
+        return 0;
+    }
+}

--- a/src/Console/Application/Collections/CollectionGetCommand.cs
+++ b/src/Console/Application/Collections/CollectionGetCommand.cs
@@ -1,0 +1,44 @@
+﻿namespace Haystac.Console.Application.Collections;
+
+public class CollectionGetCommand : AsyncCommand<CollectionGetCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<CollectionId>")]
+        [Description("Name of the Collection to remove the item from")]
+        public string CollectionId { get; set; } = string.Empty;
+
+        [CommandArgument(1, "<FilePath>")]
+        [Description("Path of output file to write JSON to")]
+        public string OutputFile { get; set; } = string.Empty;
+    }
+
+    private readonly ICollectionRepository _collections;
+
+    public CollectionGetCommand(ICollectionRepository collections)
+    {
+        _collections = collections;
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        Helper.WriteDivider($"Fetching Collection");
+
+        //< TODO - Any parameter validation?
+
+        Helper.Write("Attempting to retrieve the following:");
+        Helper.Write($"Collection: [yellow]{settings.CollectionId.EscapeMarkup()}[/]");
+
+        var dto = await _collections.GetCollectionByIdAsync(settings.CollectionId);
+
+        Helper.Write($"\t .. Done!");
+        Helper.Write($"Saving to file: [yellow]{settings.OutputFile.EscapeMarkup()}[/]");
+
+        var json = JsonSerializer.Serialize(dto);
+        await File.WriteAllTextAsync(settings.OutputFile, json);
+
+        Helper.Write($"\t .. Done!");
+
+        return 0;
+    }
+}

--- a/src/Console/Application/Collections/CollectionListCommand.cs
+++ b/src/Console/Application/Collections/CollectionListCommand.cs
@@ -1,6 +1,4 @@
-﻿using Haystac.Application.Collections.Queries;
-
-namespace Haystac.Console.Application.Collections;
+﻿namespace Haystac.Console.Application.Collections;
 
 public class CollectionListCommand : AsyncCommand<CollectionListCommand.Settings>
 {
@@ -11,11 +9,11 @@ public class CollectionListCommand : AsyncCommand<CollectionListCommand.Settings
         public int Count { get; set; } = 10;
     }
 
-    private readonly IMediator _mediator;
+    private readonly ICollectionRepository _collections;
 
-    public CollectionListCommand(IMediator mediator)
+    public CollectionListCommand(ICollectionRepository collections)
     {
-        _mediator = mediator;
+        _collections = collections;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
@@ -23,17 +21,17 @@ public class CollectionListCommand : AsyncCommand<CollectionListCommand.Settings
         Helper.WriteDivider($"Listing Collections");
 
         Helper.Write("Fetching collections..");
-        var collecs = await _mediator.Send(new GetAllCollectionsQuery());
+        var collecs = await _collections.GetAllCollectionsAsync();
         Helper.Write($" - Done! Found [yellow]{collecs.Count}[/] Collections");
 
         var table = new Table();
         table.AddColumn("Name");
-        table.AddColumn("Total Items");
+        table.AddColumn("Type");
         table.AddColumn("Description");
 
         foreach (var collec in collecs)
         {
-            table.AddRow(collec.Identifier, $"[yellow]{collec.Items.Count}[/]", collec.Description);
+            table.AddRow(collec.Identifier, $"[yellow]{collec.Type}[/]", collec.Description);
         }
 
         table.Expand();

--- a/src/Console/Infrastructure/Http/BearerTokenHandler.cs
+++ b/src/Console/Infrastructure/Http/BearerTokenHandler.cs
@@ -16,12 +16,7 @@ public class BearerTokenHandler : DelegatingHandler
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        var token = await _token.GetTokenAsync();
-
-        if (token == null)
-        {
-            throw new Exception("Unable to retrieve cached credentials, please login via 'haystac login'");
-        }
+        var token = await _token.GetTokenAsync() ?? "";
 
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 

--- a/src/Console/Infrastructure/Repositories/AuthenticationRepository.cs
+++ b/src/Console/Infrastructure/Repositories/AuthenticationRepository.cs
@@ -32,7 +32,7 @@ public class AuthenticationRepository : IAuthenticationRepository
 
         if (!response.IsSuccessStatusCode)
         {
-            return Result.Failure(new[] { responseBody });
+            return Result.Failure(new[] { $"{response.StatusCode}: {responseBody}" });
         }
 
         await _token.SetTokenAsync(responseBody);

--- a/src/Console/Infrastructure/Repositories/CollectionRepository.cs
+++ b/src/Console/Infrastructure/Repositories/CollectionRepository.cs
@@ -9,23 +9,90 @@ public class CollectionRepository : ICollectionRepository
         _client = client;
     }
 
-    public Task<Guid> CreateCollectionAsync(CollectionDto dto)
+    public async Task<Guid> CreateCollectionAsync(CollectionDto dto)
     {
-        throw new NotImplementedException();
+        var json = JsonSerializer.Serialize(dto);
+        var requestContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var route = $"{dto.Identifier}";
+        var response = await _client.PostAsync(route, requestContent);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to create Collection due to: {responseBody}");
+        }
+
+        return JsonSerializer.Deserialize<Guid>(responseBody);
     }
 
-    public Task<CollectionDto> GetCollectionByIdAsync(string collectionId)
+    public async Task<List<CollectionDto>> GetAllCollectionsAsync()
     {
-        throw new NotImplementedException();
+        var request = new HttpRequestMessage(HttpMethod.Get, "");
+
+        var response = await _client.SendAsync(request);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to retrieve Collection due to: {responseBody}");
+        }
+
+        var dtos = JsonSerializer.Deserialize<List<CollectionDto>>(responseBody);
+        if (dtos == null) throw new Exception($"Failed to deserialize response: {responseBody}");
+
+        return dtos;
     }
 
-    public Task UpdateCollectionAsync(CollectionDto dto)
+    public async Task<CollectionDto> GetCollectionByIdAsync(string collectionId)
     {
-        throw new NotImplementedException();
+        var route = $@"collections\{collectionId}";
+        var request = new HttpRequestMessage(HttpMethod.Get, route);
+
+        var response = await _client.SendAsync(request);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to retrieve Collection due to: {responseBody}");
+        }
+
+        var dto = JsonSerializer.Deserialize<CollectionDto>(responseBody);
+        if (dto == null) throw new Exception($"Failed to deserialize response: {responseBody}");
+
+        return dto;
     }
 
-    public Task DeleteCollectionAsync(string collectionId)
+    public async Task UpdateCollectionAsync(CollectionDto dto)
     {
-        throw new NotImplementedException();
+        var json = JsonSerializer.Serialize(dto);
+        var requestContent = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var route = $@"{dto.Identifier}";
+        var response = await _client.PutAsync(route, requestContent);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Failed to update Collection due to: {responseBody}");
+        }
+
+        return;
+    }
+
+    public async Task DeleteCollectionAsync(string collectionId)
+    {
+        var route = $@"{collectionId}";
+        var delRequest = new HttpRequestMessage(HttpMethod.Delete, route);
+
+        var response = await _client.SendAsync(delRequest);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Failed to delete Collection due to: {responseBody}");
+        }
+
+        return;
     }
 }

--- a/src/Console/Infrastructure/Repositories/Interfaces/ICollectionRepository.cs
+++ b/src/Console/Infrastructure/Repositories/Interfaces/ICollectionRepository.cs
@@ -3,6 +3,7 @@
 public interface ICollectionRepository
 {
     public Task<Guid> CreateCollectionAsync(CollectionDto dto);
+    public Task<List<CollectionDto>> GetAllCollectionsAsync();
     public Task<CollectionDto> GetCollectionByIdAsync(string collectionId);
     public Task UpdateCollectionAsync(CollectionDto dto);
     public Task DeleteCollectionAsync(string collectionId);

--- a/src/Console/Infrastructure/Services/TokenService.cs
+++ b/src/Console/Infrastructure/Services/TokenService.cs
@@ -4,18 +4,18 @@ namespace Haystac.Console.Infrastructure.Services;
 
 public class TokenService : ITokenService
 {
-    private static readonly string VAR_NAME = $"{Prefixes.ENV_PREFIX}__AccessToken";
+    private static readonly string VAR_NAME = $"HAYSTAC_TOKEN";
 
     public Task<string?> GetTokenAsync()
     {
-        var token = Environment.GetEnvironmentVariable(VAR_NAME);
+        var token = Environment.GetEnvironmentVariable(VAR_NAME, EnvironmentVariableTarget.User);
 
         return Task.FromResult(token);
     }
 
     public Task SetTokenAsync(string? token)
     {
-        Environment.SetEnvironmentVariable(VAR_NAME, token);
+        Environment.SetEnvironmentVariable(VAR_NAME, token, EnvironmentVariableTarget.User);
 
         return Task.CompletedTask;
     }

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -3,6 +3,7 @@
 using Serilog;
 
 using Haystac.Console.Common;
+using Haystac.Console.Application.Authentication;
 using Haystac.Console.Application.Items;
 using Haystac.Console.Application.Collections;
 
@@ -16,7 +17,6 @@ var config = Configuration.GetConfiguration();
 builder.UseSerilog(Logging.GetLogger());
 builder.ConfigureServices(services =>
 {
-    services.AddApplicationServices();
     services.AddConsoleServices(config);
 });
 
@@ -27,6 +27,18 @@ app.Configure(config =>
 {
     config.SetApplicationName("Haystac CLI");
 
+    config.SetExceptionHandler(ex =>
+    {
+        AnsiConsole.WriteException(ex);
+        return -99;
+    });
+
+    config.AddCommand<LogInCommand>("login")
+          .WithDescription("Attempts to authenticate & cache credentials for remote Haystac API");
+
+    config.AddCommand<LogOutCommand>("logout")
+          .WithDescription("Clears any local credentials for remote Haystac API");
+
     config.AddBranch("collection", branch =>
     {
         branch.AddCommand<CollectionAddCommand>("add")
@@ -35,6 +47,18 @@ app.Configure(config =>
 
         branch.AddCommand<CollectionListCommand>("list")
               .WithDescription("Lists detailed information about each Collection currently stored in the DB");
+
+        branch.AddCommand<CollectionGetCommand>("get")
+              .WithDescription("Retrieves a specific Collection and writes it to local JSON file.")
+              .WithExample(new[] { "get", "CollectionName", @"C:\_test\collection_name.json" });
+
+        branch.AddCommand<CollectionUpdateCommand>("update")
+              .WithDescription("Attempts to update existing STAC Collection with data parsed from local JSON.")
+              .WithExample(new[] { "update", @"C:\_test\stac_collection.json" });
+
+        branch.AddCommand<CollectionDeleteCommand>("delete")
+              .WithDescription("Retrieves a specific Collection and writes it to loca JSON file.")
+              .WithExample(new[] { "delete", "CollectionName" });
     });
 
     config.AddBranch("item", branch =>
@@ -42,6 +66,14 @@ app.Configure(config =>
         branch.AddCommand<ItemAddCommand>("add")
               .WithDescription("Attempts to import a STAC Item into an existing STAC Collection from an input JSON file")
               .WithExample(new[] { "add", @"C:\_test\stac_item.json" });
+
+        branch.AddCommand<ItemGetCommand>("get")
+              .WithDescription("Retrieves a specific Item and writes it to local JSON file.")
+              .WithExample(new[] { "get", "CollectionName", "ItemName", @"C:\_test\item_name.json" });
+
+        branch.AddCommand<ItemUpdateCommand>("update")
+              .WithDescription("Retrieves a specific Item and writes it to local JSON file.")
+              .WithExample(new[] { "update", @"C:\_test\stac_item.json" });
 
         branch.AddCommand<ItemDeleteCommand>("delete")
               .WithDescription("Attempts to delete the given Item from the given Collection")

--- a/src/Console/appsettings.json
+++ b/src/Console/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "Haystac": {
+    "ApiRoute": "https://localhost:7010"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "host=localhost;port=5432;database=haystac-test;username=postgres;password=ponos"
   },

--- a/src/Domain/Entities/Collection.cs
+++ b/src/Domain/Entities/Collection.cs
@@ -5,6 +5,11 @@
 public class Collection : BaseStacEntity
 {
     /// <summary>
+    /// The type flag of the <see cref="Collection"/> (or Catalog) entity - only 'Collection' and 'Catalog' are allowed
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
     /// A short, descriptive one-line title for the <see cref="Collection"/> entity
     /// </summary>
     public string? Title { get; set; }

--- a/src/WebApi/Controllers/AuthenticationController.cs
+++ b/src/WebApi/Controllers/AuthenticationController.cs
@@ -15,7 +15,13 @@ public class AuthenticationController : ControllerBase
 
     [HttpPost("signin")]
     public async Task<ActionResult<string?>> SignIn([FromBody] PasswordSignInCommand cmd)
-        => await _mediator.Send(cmd);
+    {
+        var token = await _mediator.Send(cmd);
+
+        if (token == null) return Unauthorized();
+
+        return Ok(token);
+    }
 
     //< TODO - Add: 'resetpassword', 'changepassword', 'multifactor'
 }

--- a/src/WebApi/Controllers/CollectionsController.cs
+++ b/src/WebApi/Controllers/CollectionsController.cs
@@ -21,8 +21,8 @@ public class CollectionsController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<PaginatedList<CollectionDto>>> GetCollections([FromQuery] GetCollectionsWithPaginationQuery query)
-        => await _mediator.Send(query);
+    public async Task<ActionResult<List<CollectionDto>>> GetCollections()
+        => await _mediator.Send(new GetAllCollectionsQuery());
 
     [HttpGet("{id}")]
     public async Task<ActionResult<CollectionDto>> GetCollectionById(string id)


### PR DESCRIPTION
Closes #6
Closes #9 
Closes #12

Key Changes:
- Added basic README.md structure and initial info
- Added 'Type' as field within 'Collection' domain entity so we can have both Catalog and Collections stored there
- Completed 'CollectionRepository' and (mostly) tested it
- Fixed issue with access token being stored as process env var, changed to user env var.
- Changed `/collections` to always use `GetAllCollectionsQuery` rather than paging
- Other changes